### PR TITLE
Add SIGUSR1 inbox handling to Codex launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ brew install --cask codex
 
 Then simply run `codex` to get started.
 
+Codex also supports operator instruction injection for running sessions on Unix:
+write instructions to `CODEX_INBOX_FILE` (or `/tmp/codex-inbox-<pid>.md` by default) and send
+`SIGUSR1` to the running `codex` process.
+
 <details>
 <summary>You can also go to the <a href="https://github.com/openai/codex/releases/latest">latest GitHub Release</a> and download the appropriate binary for your platform.</summary>
 

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -2,7 +2,7 @@
 // Unified entry point for the Codex CLI.
 
 import { spawn } from "node:child_process";
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { createRequire } from "node:module";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -177,6 +177,16 @@ const child = spawn(binaryPath, process.argv.slice(2), {
   env,
 });
 
+const inboxPath =
+  process.env.CODEX_INBOX_FILE ?? `/tmp/codex-inbox-${process.pid}.md`;
+
+function logDebug(message) {
+  if (process.env.CODEX_DEBUG_SIGNALS === "1") {
+    // eslint-disable-next-line no-console
+    console.error(`[codex signal] ${message}`);
+  }
+}
+
 child.on("error", (err) => {
   // Typically triggered when the binary is missing or not executable.
   // Re-throwing here will terminate the parent with a non-zero exit code
@@ -203,6 +213,28 @@ const forwardSignal = (signal) => {
 
 ["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
   process.on(sig, () => forwardSignal(sig));
+});
+
+process.on("SIGUSR1", () => {
+  if (!existsSync(inboxPath)) {
+    logDebug(`SIGUSR1 received but inbox file not found: ${inboxPath}`);
+    return;
+  }
+
+  let inboxText = "";
+  try {
+    inboxText = readFileSync(inboxPath, "utf8");
+  } catch {
+    logDebug(`SIGUSR1 received but inbox file could not be read: ${inboxPath}`);
+    return;
+  }
+
+  if (!inboxText.trim()) {
+    logDebug(`SIGUSR1 received with empty inbox file: ${inboxPath}`);
+    return;
+  }
+
+  forwardSignal("SIGUSR1");
 });
 
 // When the child exits, mirror its termination reason in the parent so that


### PR DESCRIPTION
### Motivation
- Allow operator/user instruction injection into a running Codex session via a filesystem inbox and `SIGUSR1`, while ensuring injection happens at a safe point and not changing existing termination signal semantics.

### Description
- In `codex-cli/bin/codex.js` import `readFileSync`, resolve `inboxPath` from `process.env.CODEX_INBOX_FILE` or `/tmp/codex-inbox-<pid>.md`, and add a `logDebug` helper controlled by `CODEX_DEBUG_SIGNALS`.
- Register a `SIGUSR1` handler that checks the inbox file for existence, readability, and non-empty contents, logs a debug message when missing/unreadable/empty, and forwards `SIGUSR1` to the spawned native `codex` child when content is present.
- Leave existing `SIGINT`/`SIGTERM`/`SIGHUP` forwarding behavior unchanged.
- Document the feature and `CODEX_INBOX_FILE` override in `README.md`.

### Testing
- Ran `node --check codex-cli/bin/codex.js` to validate the launcher parses and the new handler code is syntactically valid, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74a138ee883279cb4677ce44af079)