### PR TITLE
Add SIGUSR1 inbox injection plumbing in launcher and core

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ brew install --cask codex
 
 Then simply run `codex` to get started.
 
+On Linux and macOS, you can inject a message into a running Codex session by writing it to
+`/tmp/codex-inbox-<pid>.md` (or the path in `CODEX_INBOX_FILE`) and sending `SIGUSR1` to the
+Codex process. Codex reads the file at the next safe point, injects it as a new user turn, and
+deletes the inbox file.
+
 <details>
 <summary>You can also go to the <a href="https://github.com/openai/codex/releases/latest">latest GitHub Release</a> and download the appropriate binary for your platform.</summary>
 

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -2,7 +2,7 @@
 // Unified entry point for the Codex CLI.
 
 import { spawn } from "node:child_process";
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { createRequire } from "node:module";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -177,6 +177,9 @@ const child = spawn(binaryPath, process.argv.slice(2), {
   env,
 });
 
+const inboxPath =
+  process.env.CODEX_INBOX_FILE ?? `/tmp/codex-inbox-${process.pid}.md`;
+
 child.on("error", (err) => {
   // Typically triggered when the binary is missing or not executable.
   // Re-throwing here will terminate the parent with a non-zero exit code
@@ -204,6 +207,24 @@ const forwardSignal = (signal) => {
 ["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
   process.on(sig, () => forwardSignal(sig));
 });
+
+if (process.platform !== "win32") {
+  process.on("SIGUSR1", () => {
+    if (!existsSync(inboxPath)) {
+      return;
+    }
+
+    try {
+      if (statSync(inboxPath).size === 0) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    forwardSignal("SIGUSR1");
+  });
+}
 
 // When the child exits, mirror its termination reason in the parent so that
 // shell scripts and other tooling observe the correct exit status.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4,7 +4,9 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use crate::AuthManager;
 use crate::CodexAuth;
@@ -421,9 +423,16 @@ pub(crate) struct CodexSpawnArgs {
 
 pub(crate) const INITIAL_SUBMIT_ID: &str = "";
 pub(crate) const SUBMISSION_CHANNEL_CAPACITY: usize = 512;
+const CODEX_INBOX_FILE_ENV_VAR: &str = "CODEX_INBOX_FILE";
 const CYBER_VERIFY_URL: &str = "https://chatgpt.com/cyber";
 const CYBER_SAFETY_URL: &str = "https://developers.openai.com/codex/concepts/cyber-safety";
 const DIRECT_APP_TOOL_EXPOSURE_THRESHOLD: usize = 100;
+
+fn codex_inbox_path() -> PathBuf {
+    std::env::var_os(CODEX_INBOX_FILE_ENV_VAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(format!("/tmp/codex-inbox-{}.md", std::process::id())))
+}
 
 impl Codex {
     /// Spawn a new [`Codex`] and initialize the session.
@@ -811,6 +820,8 @@ pub(crate) struct Session {
     pub(crate) services: SessionServices,
     js_repl: Arc<JsReplHandle>,
     next_internal_sub_id: AtomicU64,
+    #[cfg(unix)]
+    sigusr1_pending: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Debug)]
@@ -1906,6 +1917,8 @@ impl Session {
         ));
         let (out_of_band_elicitation_paused, _out_of_band_elicitation_paused_rx) =
             watch::channel(false);
+        #[cfg(unix)]
+        let sigusr1_pending = Arc::new(AtomicBool::new(false));
 
         let sess = Arc::new(Session {
             conversation_id,
@@ -1922,7 +1935,11 @@ impl Session {
             services,
             js_repl,
             next_internal_sub_id: AtomicU64::new(0),
+            #[cfg(unix)]
+            sigusr1_pending: Arc::clone(&sigusr1_pending),
         });
+        #[cfg(unix)]
+        sess.spawn_sigusr1_listener(sigusr1_pending);
         if let Some(network_policy_decider_session) = network_policy_decider_session {
             let mut guard = network_policy_decider_session.write().await;
             *guard = Arc::downgrade(&sess);
@@ -4009,6 +4026,68 @@ impl Session {
         }
     }
 
+    #[cfg(unix)]
+    fn spawn_sigusr1_listener(&self, sigusr1_pending: Arc<AtomicBool>) {
+        tokio::spawn(async move {
+            let Ok(mut sigusr1) =
+                tokio::signal::unix::signal(tokio::signal::unix::SignalKind::user_defined1())
+            else {
+                warn!("failed to register SIGUSR1 handler");
+                return;
+            };
+
+            while sigusr1.recv().await.is_some() {
+                sigusr1_pending.store(true, Ordering::Release);
+            }
+        });
+    }
+
+    #[cfg(unix)]
+    async fn maybe_inject_sigusr1_inbox(&self) {
+        if !self.sigusr1_pending.swap(false, Ordering::AcqRel) {
+            return;
+        }
+
+        let inbox_path = codex_inbox_path();
+        let inbox_contents = match tokio::fs::read_to_string(&inbox_path).await {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(err) => {
+                warn!(
+                    "failed reading SIGUSR1 inbox file {}: {err}",
+                    inbox_path.display()
+                );
+                return;
+            }
+        };
+
+        if inbox_contents.is_empty() {
+            return;
+        }
+
+        if let Err(err) = tokio::fs::remove_file(&inbox_path).await
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                "failed deleting SIGUSR1 inbox file {}: {err}",
+                inbox_path.display()
+            );
+        }
+
+        if let Err(err) = self
+            .steer_input(
+                vec![UserInput::Text {
+                    text: inbox_contents,
+                    text_elements: Vec::new(),
+                }],
+                None,
+            )
+            .await
+        {
+            warn!("failed to inject SIGUSR1 inbox message: {err:?}");
+        }
+    }
+
     pub async fn list_resources(
         &self,
         server: &str,
@@ -5791,6 +5870,9 @@ pub(crate) async fn run_turn(
         prewarmed_client_session.unwrap_or_else(|| sess.services.model_client.new_session());
 
     loop {
+        #[cfg(unix)]
+        sess.maybe_inject_sigusr1_inbox().await;
+
         if run_pending_session_start_hooks(&sess, &turn_context).await {
             break;
         }


### PR DESCRIPTION
### Motivation

- Allow external processes to inject a user message into a running Codex session by writing text to a file and sending `SIGUSR1`, enabling simple automation or integrations without UI or RPC changes.

### Description

- Node launcher: resolve inbox path from `CODEX_INBOX_FILE` or `/tmp/codex-inbox-<pid>.md`, register a Unix-only `SIGUSR1` handler that validates the inbox file exists and is non-empty before forwarding `SIGUSR1` to the Rust child, and leave existing `SIGINT`/`SIGTERM`/`SIGHUP` behavior unchanged (changes in `codex-cli/bin/codex.js`).
- Rust core: add `CODEX_INBOX_FILE` env var helper `codex_inbox_path()` and a `sigusr1_pending` `AtomicBool` (unix-only) on `Session`, spawn a Tokio `SIGUSR1` listener that flips the flag, and add `maybe_inject_sigusr1_inbox()` which is invoked at the start of each `run_turn` loop iteration to read the inbox file, no-op if missing/empty, delete the file, and inject the contents as a `UserInput::Text` via `steer_input` (changes in `codex-rs/core/src/codex.rs`).
- Documentation: add a short README note describing the feature and the `CODEX_INBOX_FILE` override.

### Testing

- Ran `node --check codex-cli/bin/codex.js` which succeeded.
- Ran `cargo fmt` in `codex-rs` which completed successfully.
- Attempted `cargo test -p codex-core` but the run failed in this environment due to downloading a prebuilt `rusty_v8` archive (network/HTTP 403), so full test suite could not complete here.
- Attempted local argument-comment lint wrappers and installing helper tools but those could not be run due to missing tools or network restrictions; no runtime regressions observed from quick checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74f73bf448327afb29937443a8b91)