### PR TITLE
Add SIGUSR2-based live config/rules reload (launcher + core)

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -205,6 +205,14 @@ const forwardSignal = (signal) => {
   process.on(sig, () => forwardSignal(sig));
 });
 
+// SIGHUP is already used to forward terminal hangups to the child.
+// SIGUSR2 is reserved for live config/rules reload.
+if (process.platform !== "win32") {
+  process.on("SIGUSR2", () => {
+    forwardSignal("SIGUSR2");
+  });
+}
+
 // When the child exits, mirror its termination reason in the parent so that
 // shell scripts and other tooling observe the correct exit status.
 // Wrap the lifetime of the child process in a Promise so that we can await

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4,7 +4,9 @@ use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use crate::AuthManager;
 use crate::CodexAuth;
@@ -164,6 +166,8 @@ use crate::client_common::ResponseEvent;
 use crate::codex_thread::ThreadConfigSnapshot;
 use crate::compact::collect_user_messages;
 use crate::config::Config;
+use crate::config::ConfigOverrides;
+use crate::config::ConfigToml;
 use crate::config::Constrained;
 use crate::config::ConstraintResult;
 use crate::config::GhostSnapshotConfig;
@@ -810,6 +814,7 @@ pub(crate) struct Session {
     pub(crate) guardian_review_session: GuardianReviewSessionManager,
     pub(crate) services: SessionServices,
     js_repl: Arc<JsReplHandle>,
+    pending_sigusr2_reload: AtomicBool,
     next_internal_sub_id: AtomicU64,
 }
 
@@ -1239,6 +1244,28 @@ impl Session {
         } else {
             Some(beta_features_header)
         }
+    }
+
+    fn spawn_sigusr2_listener(sess: &Arc<Self>) {
+        #[cfg(unix)]
+        {
+            let sess = Arc::clone(sess);
+            tokio::spawn(async move {
+                use tokio::signal::unix::SignalKind;
+                use tokio::signal::unix::signal;
+
+                let Ok(mut signal_stream) = signal(SignalKind::user_defined2()) else {
+                    warn!("failed to register SIGUSR2 handler for config reload");
+                    return;
+                };
+
+                while signal_stream.recv().await.is_some() {
+                    sess.pending_sigusr2_reload.store(true, Ordering::Release);
+                }
+            });
+        }
+        #[cfg(not(unix))]
+        let _ = sess;
     }
 
     async fn start_managed_network_proxy(
@@ -1921,8 +1948,10 @@ impl Session {
             guardian_review_session: GuardianReviewSessionManager::default(),
             services,
             js_repl,
+            pending_sigusr2_reload: AtomicBool::new(false),
             next_internal_sub_id: AtomicU64::new(0),
         });
+        Session::spawn_sigusr2_listener(&sess);
         if let Some(network_policy_decider_session) = network_policy_decider_session {
             let mut guard = network_policy_decider_session.write().await;
             *guard = Arc::downgrade(&sess);
@@ -2573,13 +2602,104 @@ impl Session {
         };
 
         let mut state = self.state.lock().await;
-        let mut config = (*state.session_configuration.original_config_do_not_use).clone();
+        let current_config = (*state.session_configuration.original_config_do_not_use).clone();
+        let mut config = current_config.clone();
         config.config_layer_stack = config
             .config_layer_stack
             .with_user_config(&config_toml_path, user_config);
-        state.session_configuration.original_config_do_not_use = Arc::new(config);
+
+        let merged_toml = config.config_layer_stack.effective_config();
+        let config_toml: ConfigToml = match merged_toml.try_into() {
+            Ok(config_toml) => config_toml,
+            Err(err) => {
+                warn!("failed to deserialize merged config while reloading layer: {err}");
+                return;
+            }
+        };
+
+        let reloaded_config = match Config::load_config_with_layer_stack(
+            config_toml,
+            ConfigOverrides {
+                cwd: Some(current_config.cwd.to_path_buf()),
+                codex_self_exe: current_config.codex_self_exe.clone(),
+                codex_linux_sandbox_exe: current_config.codex_linux_sandbox_exe.clone(),
+                main_execve_wrapper_exe: current_config.main_execve_wrapper_exe.clone(),
+                js_repl_node_path: current_config.js_repl_node_path.clone(),
+                js_repl_node_module_dirs: Some(current_config.js_repl_node_module_dirs.clone()),
+                zsh_path: current_config.zsh_path.clone(),
+                ephemeral: Some(current_config.ephemeral),
+                ..ConfigOverrides::default()
+            },
+            current_config.codex_home.clone(),
+            config.config_layer_stack.clone(),
+        ) {
+            Ok(reloaded_config) => reloaded_config,
+            Err(err) => {
+                warn!("failed to rebuild config while reloading layer: {err}");
+                return;
+            }
+        };
+
+        let previous_model = state
+            .session_configuration
+            .collaboration_mode
+            .model()
+            .to_string();
+        let next_model = reloaded_config
+            .model
+            .clone()
+            .unwrap_or_else(|| previous_model.clone());
+        state.session_configuration.provider = reloaded_config.model_provider.clone();
+        state.session_configuration.collaboration_mode =
+            state.session_configuration.collaboration_mode.with_updates(
+                Some(next_model),
+                reloaded_config.model_reasoning_effort,
+                /*developer_instructions*/ None,
+            );
+        state.session_configuration.model_reasoning_summary =
+            reloaded_config.model_reasoning_summary;
+
+        if state.session_configuration.approval_policy.value()
+            != reloaded_config.permissions.approval_policy.value()
+        {
+            warn!(
+                "SIGUSR2 config reload ignored approval policy change for active session (restart required)"
+            );
+        }
+        if state.session_configuration.sandbox_policy.get()
+            != reloaded_config.permissions.sandbox_policy.get()
+        {
+            warn!(
+                "SIGUSR2 config reload ignored sandbox policy change for active session (restart required)"
+            );
+        }
+        if state.session_configuration.cwd.as_path() != reloaded_config.cwd.as_path() {
+            warn!("SIGUSR2 config reload ignored cwd change for active session (restart required)");
+        }
+
+        state.session_configuration.original_config_do_not_use = Arc::new(reloaded_config);
         self.services.skills_manager.clear_cache();
         self.services.plugins_manager.clear_cache();
+    }
+
+    async fn maybe_reload_config_from_sigusr2(&self) {
+        if !self.pending_sigusr2_reload.swap(false, Ordering::AcqRel) {
+            return;
+        }
+
+        self.reload_user_config_layer().await;
+        let config_layer_stack = {
+            let state = self.state.lock().await;
+            state
+                .session_configuration
+                .original_config_do_not_use
+                .config_layer_stack
+                .clone()
+        };
+        if let Err(err) = self.services.exec_policy.reload(&config_layer_stack).await {
+            warn!("failed to reload rules from SIGUSR2: {err}");
+        }
+        println!("[config reloaded]");
     }
 
     pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {
@@ -4245,6 +4365,7 @@ impl Session {
 async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiver<Submission>) {
     // To break out of this loop, send Op::Shutdown.
     while let Ok(sub) = rx_sub.recv().await {
+        sess.maybe_reload_config_from_sigusr2().await;
         debug!(?sub, "Submission");
         let dispatch_span = submission_dispatch_span(&sub);
         let should_exit = async {
@@ -5794,6 +5915,7 @@ pub(crate) async fn run_turn(
         if run_pending_session_start_hooks(&sess, &turn_context).await {
             break;
         }
+        sess.maybe_reload_config_from_sigusr2().await;
 
         // Note that pending_input would be something like a message the user
         // submitted through the UI while the model was running. Though the UI

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -223,6 +223,18 @@ impl ExecPolicyManager {
         self.policy.load_full()
     }
 
+    pub(crate) async fn reload(
+        &self,
+        config_stack: &ConfigLayerStack,
+    ) -> Result<(), ExecPolicyError> {
+        let (policy, warning) = load_exec_policy_with_warning(config_stack).await?;
+        if let Some(err) = warning.as_ref() {
+            tracing::warn!("failed to parse rules while reloading: {err}");
+        }
+        self.policy.store(Arc::new(policy));
+        Ok(())
+    }
+
     pub(crate) async fn create_exec_approval_requirement_for_command(
         &self,
         req: ExecApprovalRequest<'_>,


### PR DESCRIPTION
### Motivation

- Provide a Unix-only live config/rules reload mechanism that does not reuse `SIGHUP` (already forwarded) by adding `SIGUSR2` as the reload signal. 
- Ensure reloads are applied safely between work units so in-flight LLM calls and tool executions are not interrupted. 

### Description

- Node launcher: forward `SIGUSR2` to the Rust child on non-Windows platforms by adding a Unix-only handler in `codex-cli/bin/codex.js`. 
- Rust core: add a `tokio::signal::unix` listener that sets an atomic reload flag (`pending_sigusr2_reload`) and spawn it at session creation so the process reacts to `SIGUSR2` on Unix. 
- Safe-point checks: call `maybe_reload_config_from_sigusr2()` at the start of the submission loop and at the start of each agent turn so reloads occur only between work units. 
- Reload behavior: update `reload_user_config_layer()` to rebuild the effective `Config` from the merged layer stack (including the updated user layer), attempt to reconstruct a live `Config` via `Config::load_config_with_layer_stack` (preserving harness overrides), apply live-safe changes immediately (model/provider/reasoning summary), warn when unsafe-to-change settings are detected (approval policy, sandbox policy, cwd), clear skills/plugins caches, reload exec-policy rules via a new `ExecPolicyManager::reload()` helper, and print `[config reloaded]` to stdout. 
- Exec policy: add `ExecPolicyManager::reload` to reparse and atomically swap in new rules. 

### Testing

- Ran `cargo fmt` successfully in `codex-rs`. 
- Attempted `cargo test -p codex-core --lib reload_user_config_layer_updates_effective_apps_config`, but the build failed in this environment due to an external `rusty_v8` artifact download being blocked (`403 Forbidden`), so the unit test could not complete. 
- `just fmt` and `just argument-comment-lint` were not run because `just` is not installed and attempts to install it were blocked by network access restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c74f756ce4832795935791cbdf2456)